### PR TITLE
Add `HamiltonianGate` single analog gate

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -517,8 +517,11 @@ valid-metaclass-classmethod-first-arg=cls
 # Maximum number of arguments for function / method.
 max-args=8
 
+# Maximum number of positional arguments
+max-positional-arguments=8
+
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=8
 
 # Maximum number of boolean expressions in an if statement (see R0916).
 max-bool-expr=5

--- a/qiskit_pasqal_provider/providers/gate.py
+++ b/qiskit_pasqal_provider/providers/gate.py
@@ -1,0 +1,154 @@
+"""Pasqal analog gate"""
+
+from typing import Any, Union
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from pulser.math import AbstractArray
+from qiskit.circuit import Parameter, ParameterExpression
+from qiskit.circuit.gate import Gate
+
+from qiskit_pasqal_provider.providers.pulse_utils import PasqalRegister
+
+CoordsKey = Union[str, int, float]
+
+
+class InterpolatePoints:
+    """
+    A class to hold attributes for later use on `pulser`'s `InterpolateWaveform` class.
+    It should be used to generate the points for the `HamiltonianGate` instance.
+    """
+
+    __slots__ = ("_values", "_duration", "_interpolator", "_interpolator_kwargs")
+
+    def __init__(
+        self,
+        values: ArrayLike,
+        duration: int | float | ParameterExpression = 1000,  # think how to define it
+        interpolator: str = "PchipInterpolator",
+        **interpolator_kwargs: Any,
+    ):
+        """
+        A class to hold attributes for later use on `pulser`'s `InterpolateWaveform`
+        class. It should be used to generate the points for the `HamiltonianGate`
+        instance.
+
+        Args:
+            values: an array-like data representing the points to be interpolated.
+                It can be parametrized through `qiskit.circuit.Parameter`.
+            duration: optional duration of the waveform (in ns). Defaults to 1000.
+            interpolator: The SciPy interpolation class to use. Supports
+                "PchipInterpolator" and "interp1d".
+            **interpolator_kwargs: Extra parameters to give to the chosen
+                interpolator class.
+        """
+
+        assert isinstance(duration, int | float | ParameterExpression)
+        assert isinstance(interpolator, str)
+
+        values = np.array(values)
+        self._values = values
+        self._duration = duration
+        self._interpolator = interpolator
+        self._interpolator_kwargs = interpolator_kwargs
+
+    @property
+    def duration(self) -> int | float | Parameter:
+        """duration of the waveform (in ns)"""
+        return self._duration
+
+    @property
+    def values(self) -> ArrayLike:
+        """data points for interpolation"""
+        return self._values
+
+
+class HamiltonianGate(Gate):
+    """Hamiltonian gate, an analog gate."""
+
+    def __init__(
+        self,
+        amplitude: InterpolatePoints,
+        detuning: InterpolatePoints,
+        phase: InterpolatePoints,
+        coords: ArrayLike,
+        composed_wf: Any | None = None,
+    ):
+        """
+        Hamiltonian gate is an analog gate that provides the relevant functionalities
+        to use analog quantum computing in a circuit-like environment.
+
+        Args:
+            amplitude: an InterpolatePoints instance to represent an amplitude waveform.
+            detuning: an InterpolatePoints instance to represent a detuning waveform.
+            phase: an InterpolatePoints instance to represent a phase waveform.
+            coords: an array-like containing (x, y) coordinates of the qubits.
+            composed_wf: alternative approach to generate a sequence of waveforms
+                instead of amplitude, detuning and phase
+        """
+
+        # perform some checks
+
+        if composed_wf is not None:
+            # implement it later as alternative to `InterpolatePoints`
+            raise NotImplementedError("'composed_wf' argument is not available yet.")
+
+        if not (
+            isinstance(amplitude, InterpolatePoints)
+            and isinstance(detuning, InterpolatePoints)
+            and isinstance(phase, InterpolatePoints)
+        ):
+            raise TypeError(
+                f"amplitude and detuning must be InterpolatePoints, not "
+                f"{type(amplitude)} (amplitude), {type(detuning)} (detuning)."
+            )
+
+        if amplitude.duration != detuning.duration:
+            raise ValueError(
+                f"amplitude and detuning must have the same duration times;"
+                f"amplitude duration: {amplitude.duration}, "
+                f"detuning duration: {detuning.duration}."
+            )
+
+        num_qubits = len(coords)  # type: ignore [arg-type]
+
+        super().__init__(
+            name="HG",
+            num_qubits=num_qubits,
+            params=[],
+            label="",
+            duration=amplitude.duration,  # qiskit emits warning on this, but it's needed
+            unit="dt",
+        )
+
+        self._amplitude = amplitude
+        self._detuning = detuning
+        self._phase = phase
+        self._analog_register = PasqalRegister.from_coordinates(coords, prefix="q")
+
+    @property
+    def coords(self) -> dict[str, AbstractArray]:
+        """coordinates as a dictionary where the keys are the qubits ids and values
+        are their (x, y) coordinates."""
+
+        return self._analog_register.qubits
+
+    @property
+    def analog_register(self) -> PasqalRegister:
+        """Analog register as a `PasqalRegister` instance. Not related to `qiskit`'s
+        `QuantumRegister`."""
+
+        return self._analog_register
+
+    def power(self, exponent: float, annotated: bool = False):
+        raise AttributeError("Cannot raise this gate to the power of `exponent`.")
+
+    def control(
+        self,
+        num_ctrl_qubits: int = 1,
+        label: str | None = None,
+        ctrl_state: int | str | None = None,
+        annotated: bool | None = None,
+    ):
+        raise AttributeError("Cannot have a control on an analog gate.")

--- a/qiskit_pasqal_provider/providers/pulse_utils.py
+++ b/qiskit_pasqal_provider/providers/pulse_utils.py
@@ -5,9 +5,7 @@ from dataclasses import dataclass
 import pulser
 from pulser.register import Register
 import qiskit
-from qiskit.pulse import Constant, Schedule, Play
-from qiskit.pulse.channels import PulseChannel
-from qiskit.pulse.library.pulse import Pulse
+from qiskit.pulse import Constant, Schedule
 
 
 @dataclass
@@ -23,29 +21,14 @@ class TwoPhotonPulse:
     phase: float = 0
 
 
-class TwoPhotonSchedule(Schedule):
-    """
-    Schedule class that holds 2 pulses (rabi, detuning) suitable for Neutral Atom Analog devices.
-    """
-
-    def __init__(
-        self,
-        *,
-        channel: PulseChannel,
-        rabi: Pulse | None = None,
-        detuning: Pulse | None = None,
-        name: str | None = None,
-        metadata: dict | None = None,
-    ):
-        schedules = [
-            Play(rabi, channel=channel, name=rabi.name or "rabi"),
-            Play(detuning, channel=channel, name=detuning.name or "detuning"),
-        ]
-        super().__init__(*schedules, name=name, metadata=metadata)
-
-
 def to_pulser(sched: Schedule) -> list[tuple[pulser.Pulse, str]]:
-    """Utility function to convert a Qiskit Pulse Schedule into a Pulser Sequence."""
+    """
+    Utility function to convert a Qiskit Pulse Schedule into a Pulser Sequence.
+
+
+    Notice: this class will be completely refactored.
+
+    """
 
     pulses: dict[int, TwoPhotonPulse] = {}
     for time, instruction in sched.instructions:

--- a/technical_diagrams/qiskit-pasqal-provider_diagrams.drawio
+++ b/technical_diagrams/qiskit-pasqal-provider_diagrams.drawio
@@ -1,4 +1,4 @@
-<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.0.9 Chrome/128.0.6613.186 Electron/32.2.5 Safari/537.36" version="26.0.9" pages="3">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.0.16 Chrome/132.0.6834.196 Electron/34.2.0 Safari/537.36" version="26.0.16" pages="5">
   <diagram name="inheritance/classes" id="X4m6LKrLwDku7PwRh3gT">
     <mxGraphModel dx="1383" dy="917" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
@@ -204,7 +204,7 @@
     </mxGraphModel>
   </diagram>
   <diagram id="9DvkTdYDK_hXoEfJ7Mpa" name="activity diagram (core)">
-    <mxGraphModel dx="1251" dy="830" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+    <mxGraphModel dx="1314" dy="871" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -481,24 +481,24 @@
         <mxCell id="sWB14MhDj_UWIPNvyOvW-62" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;Activity diagram (core)&lt;/h1&gt;&lt;p&gt;System behavior from the first step inside the &lt;font face=&quot;Menlo&quot;&gt;qiskit-pasqal-provider&lt;/font&gt; package to the retrieval of job results from quantum instructions computation.&lt;/p&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;" parent="1" vertex="1">
           <mxGeometry x="80" y="40" width="280" height="140" as="geometry" />
         </mxCell>
-        <mxCell id="fL5jCMKM3DHu35Zag9iO-3" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="1">
+        <mxCell id="fL5jCMKM3DHu35Zag9iO-3" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" parent="1" vertex="1">
           <mxGeometry x="103" y="1070" width="80" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="fL5jCMKM3DHu35Zag9iO-4" value="[remote backend]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" source="fL5jCMKM3DHu35Zag9iO-3" parent="1" target="fL5jCMKM3DHu35Zag9iO-6">
+        <mxCell id="fL5jCMKM3DHu35Zag9iO-4" value="[remote backend]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" source="fL5jCMKM3DHu35Zag9iO-3" target="fL5jCMKM3DHu35Zag9iO-6" edge="1">
           <mxGeometry x="-1" relative="1" as="geometry">
             <mxPoint x="295.62" y="1090" as="targetPoint" />
             <mxPoint as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="fL5jCMKM3DHu35Zag9iO-5" value="[local backend]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="fL5jCMKM3DHu35Zag9iO-3" parent="1" target="fL5jCMKM3DHu35Zag9iO-10">
+        <mxCell id="fL5jCMKM3DHu35Zag9iO-5" value="[local backend]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="fL5jCMKM3DHu35Zag9iO-3" target="fL5jCMKM3DHu35Zag9iO-10" edge="1">
           <mxGeometry x="-1" relative="1" as="geometry">
             <mxPoint x="142.62" y="1150" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="fL5jCMKM3DHu35Zag9iO-6" value="instantiate&amp;nbsp;&lt;font face=&quot;Menlo&quot;&gt;PasqalRemoteBackend&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="1">
+        <mxCell id="fL5jCMKM3DHu35Zag9iO-6" value="instantiate&amp;nbsp;&lt;font face=&quot;Menlo&quot;&gt;PasqalRemoteBackend&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" parent="1" vertex="1">
           <mxGeometry x="304.25" y="1070" width="260" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="fL5jCMKM3DHu35Zag9iO-7" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="fL5jCMKM3DHu35Zag9iO-6" parent="1" target="s2lIr1NxqmbmZ7W-PM-g-16">
+        <mxCell id="fL5jCMKM3DHu35Zag9iO-7" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="fL5jCMKM3DHu35Zag9iO-6" target="s2lIr1NxqmbmZ7W-PM-g-16" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="434.25" y="1170" as="targetPoint" />
             <Array as="points">
@@ -507,22 +507,353 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="fL5jCMKM3DHu35Zag9iO-10" value="instantiate &lt;font face=&quot;Menlo&quot;&gt;PasqalLocalBackend&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="1">
+        <mxCell id="fL5jCMKM3DHu35Zag9iO-10" value="instantiate &lt;font face=&quot;Menlo&quot;&gt;PasqalLocalBackend&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" parent="1" vertex="1">
           <mxGeometry x="20" y="1170" width="246" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="fL5jCMKM3DHu35Zag9iO-11" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" source="fL5jCMKM3DHu35Zag9iO-10" parent="1" target="s2lIr1NxqmbmZ7W-PM-g-16">
+        <mxCell id="fL5jCMKM3DHu35Zag9iO-11" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="fL5jCMKM3DHu35Zag9iO-10" target="s2lIr1NxqmbmZ7W-PM-g-16" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="142.62" y="1270" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="fL5jCMKM3DHu35Zag9iO-26" value="define backend name" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="1">
+        <mxCell id="fL5jCMKM3DHu35Zag9iO-26" value="define backend name" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" parent="1" vertex="1">
           <mxGeometry x="82.69" y="980" width="120.62" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="fL5jCMKM3DHu35Zag9iO-27" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="1" source="fL5jCMKM3DHu35Zag9iO-26" target="fL5jCMKM3DHu35Zag9iO-3">
+        <mxCell id="fL5jCMKM3DHu35Zag9iO-27" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" parent="1" source="fL5jCMKM3DHu35Zag9iO-26" target="fL5jCMKM3DHu35Zag9iO-3" edge="1">
           <mxGeometry relative="1" as="geometry">
             <mxPoint x="223.13" y="1060" as="targetPoint" />
           </mxGeometry>
         </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram name="new proposal diagram" id="dSCncOLHvARR0GNXIThg">
+    <mxGraphModel dx="1314" dy="871" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-0" />
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-1" parent="kiI7L0eWUCCRGxfHeIEO-0" />
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-2" value="user" style="shape=umlActor;verticalLabelPosition=bottom;verticalAlign=top;html=1;strokeColor=default;align=center;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;fillColor=default;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="84.25" y="210" width="30" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-3" value="" style="ellipse;html=1;shape=startState;fillColor=#000000;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="129" y="220" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-4" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-3" target="kiI7L0eWUCCRGxfHeIEO-30">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="144" y="290.0000000000001" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-5" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="103.75" y="1340" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-6" value="[no QiskitSchedule defined]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-5" target="kiI7L0eWUCCRGxfHeIEO-13">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="363.75" y="1360" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-7" value="[has QiskitSchedule]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-5" target="kiI7L0eWUCCRGxfHeIEO-10">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="143.75" y="1420" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-8" value="call &lt;font face=&quot;Menlo&quot;&gt;PasqalBackend&lt;/font&gt;&#39;s run method" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="43.75" y="1550" width="200" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-9" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-8" target="kiI7L0eWUCCRGxfHeIEO-16">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="-46.25" y="1700" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-10" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="103.75" y="1459.96" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-11" value="[no PasqalRegister defined]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-10" target="kiI7L0eWUCCRGxfHeIEO-21">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="393.75" y="1479.96" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-12" value="[has PasqalRegister]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-10" target="kiI7L0eWUCCRGxfHeIEO-8">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="143.75" y="1559.96" as="targetPoint" />
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-13" value="create &lt;font face=&quot;Menlo&quot;&gt;QiskitSchedule&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="483.75" y="1340" width="150" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-14" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-13" target="kiI7L0eWUCCRGxfHeIEO-15">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="563.75" y="1420" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-15" value="populate with &lt;font face=&quot;Menlo&quot;&gt;QiskitPlay&lt;/font&gt; pulses" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="309.75" y="1270" width="220" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-16" value="receive &lt;font face=&quot;Menlo&quot;&gt;PasqalJob&lt;/font&gt;&lt;font face=&quot;Helvetica&quot;&gt; &lt;/font&gt;&lt;font face=&quot;Helvetica&quot;&gt;result&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="63.75" y="1625.02" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-17" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-16" target="kiI7L0eWUCCRGxfHeIEO-18">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="68.75" y="1790" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-18" value="" style="ellipse;html=1;shape=endState;fillColor=#000000;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="128.75" y="1710" width="30" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-19" value="define &lt;font face=&quot;Menlo&quot;&gt;PasqalRegister&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="363.75" y="1689" width="160" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-20" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;jumpStyle=arc;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-19" target="kiI7L0eWUCCRGxfHeIEO-10">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="343.75" y="1379.96" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="343.5" y="1709" />
+              <mxPoint x="343.5" y="1420" />
+              <mxPoint x="143.5" y="1420" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-21" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="403.75" y="1459.96" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-22" value="[no coords info]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-21" target="kiI7L0eWUCCRGxfHeIEO-24">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="583.75" y="1479.96" as="targetPoint" />
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-23" value="[has coords info]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-21" target="kiI7L0eWUCCRGxfHeIEO-27">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="443.75" y="1559.96" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-24" value="get register from layout &lt;font face=&quot;Menlo&quot;&gt;&amp;lt;SpecialLayout&amp;gt;.&amp;lt;lattice type&amp;gt;_register&lt;/font&gt; method" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="583.75" y="1444.94" width="200" height="70.04" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-25" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-24" target="kiI7L0eWUCCRGxfHeIEO-10">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="653.75" y="1609.96" as="targetPoint" />
+            <mxPoint x="673.75" y="1549.96" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="668.75" y="1419.96" />
+              <mxPoint x="143.75" y="1419.96" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-26" value="get register from layout&#39;s &lt;font face=&quot;Menlo&quot;&gt;get_traps_from_coordinates&lt;/font&gt; method" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="563.75" y="1584.94" width="210" height="70.04" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-27" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="403.75" y="1599.96" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-28" value="[no trap ID]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-27" target="kiI7L0eWUCCRGxfHeIEO-26">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="583.75" y="1619.96" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-29" value="[has trap ID]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-27" target="kiI7L0eWUCCRGxfHeIEO-19">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="443.75" y="1699.96" as="targetPoint" />
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-30" value="define a device" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="84.25" y="300" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-31" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-30" target="kiI7L0eWUCCRGxfHeIEO-51">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="144.25" y="370.0000000000001" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-32" value="create &lt;font face=&quot;Menlo&quot;&gt;PasqalTarget&lt;/font&gt; instance" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="43.75" y="550" width="200" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-33" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-32" target="kiI7L0eWUCCRGxfHeIEO-34">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="144.25" y="690" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-34" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="104.25" y="660" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-35" value="[no layout provided]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-34" target="kiI7L0eWUCCRGxfHeIEO-37">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="324.25" y="680" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="326" y="680" />
+              <mxPoint x="326" y="770" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-36" value="[layout provided]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-34" target="kiI7L0eWUCCRGxfHeIEO-47">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="144.25" y="750" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-37" value="use device layout" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="373.38" y="750" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-38" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-37" target="kiI7L0eWUCCRGxfHeIEO-39">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="433.38" y="850" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-39" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="393.38" y="840" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-40" value="[no layout available]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-39" target="kiI7L0eWUCCRGxfHeIEO-42">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="603.38" y="860" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-41" value="[layout available]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-39" target="kiI7L0eWUCCRGxfHeIEO-67">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="143.99999999999977" y="950" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="433" y="910" />
+              <mxPoint x="144" y="910" />
+              <mxPoint x="144" y="980" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-42" value="define a layout through &lt;font face=&quot;Menlo&quot;&gt;PasqalLayout&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="603.38" y="835" width="141.75" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-43" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-42" target="kiI7L0eWUCCRGxfHeIEO-34">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="454.25" y="460" as="targetPoint" />
+            <mxPoint x="705" y="835" as="sourcePoint" />
+            <Array as="points">
+              <mxPoint x="674" y="640" />
+              <mxPoint x="144" y="640" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-44" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="104.25" y="820" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-45" value="[not valid layout]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-44" target="kiI7L0eWUCCRGxfHeIEO-37">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="314.25" y="880" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="326" y="840" />
+              <mxPoint x="326" y="770" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-46" value="[valid layout for given device]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-44" target="kiI7L0eWUCCRGxfHeIEO-67">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="143.99999999999977" y="950" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-47" value="check layout" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="84.25" y="750" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-48" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-47" target="kiI7L0eWUCCRGxfHeIEO-44">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="144.25" y="830" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-49" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=0;exitDx=0;exitDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-26" target="kiI7L0eWUCCRGxfHeIEO-27">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="539.75" y="1614.98" as="targetPoint" />
+            <mxPoint x="539.75" y="1514.98" as="sourcePoint" />
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-50" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-15">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="143.5" y="1340" as="targetPoint" />
+            <mxPoint x="463.75" y="1180" as="sourcePoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-51" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="104.5" y="390" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-52" value="[custom device]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-51" target="kiI7L0eWUCCRGxfHeIEO-54">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="284.5" y="410" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-53" value="[pre-defined device]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-51" target="kiI7L0eWUCCRGxfHeIEO-32">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="144" y="430" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-54" value="create device" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="284.5" y="390" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-55" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-54" target="kiI7L0eWUCCRGxfHeIEO-32">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="344.25" y="430" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-56" value="add layout" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="410" y="470" width="120" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-57" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-56" target="kiI7L0eWUCCRGxfHeIEO-32">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="470.25" y="550" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-58" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-54" target="kiI7L0eWUCCRGxfHeIEO-56">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="433.3" y="440" as="targetPoint" />
+            <mxPoint x="433.3" y="380" as="sourcePoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-59" value="&lt;h1 style=&quot;margin-top: 0px;&quot;&gt;Activity diagram (core)&lt;/h1&gt;&lt;p&gt;System behavior from the first step inside the &lt;font face=&quot;Menlo&quot;&gt;qiskit-pasqal-provider&lt;/font&gt; package to the retrieval of job results from quantum instructions computation.&lt;/p&gt;" style="text;html=1;whiteSpace=wrap;overflow=hidden;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="80" y="40" width="280" height="140" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-60" value="" style="rhombus;whiteSpace=wrap;html=1;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="103" y="1070" width="80" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-61" value="[remote backend]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-60" target="kiI7L0eWUCCRGxfHeIEO-63">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="295.62" y="1090" as="targetPoint" />
+            <mxPoint as="offset" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-62" value="[local backend]" style="edgeStyle=orthogonalEdgeStyle;html=1;align=left;verticalAlign=top;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-60" target="kiI7L0eWUCCRGxfHeIEO-65">
+          <mxGeometry x="-1" relative="1" as="geometry">
+            <mxPoint x="142.62" y="1150" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-63" value="instantiate&amp;nbsp;&lt;font face=&quot;Menlo&quot;&gt;PasqalRemoteBackend&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="304.25" y="1070" width="260" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-64" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-63" target="kiI7L0eWUCCRGxfHeIEO-5">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="434.25" y="1170" as="targetPoint" />
+            <Array as="points">
+              <mxPoint x="434" y="1230" />
+              <mxPoint x="144" y="1230" />
+            </Array>
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-65" value="instantiate &lt;font face=&quot;Menlo&quot;&gt;PasqalLocalBackend&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="20" y="1170" width="246" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-66" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-65" target="kiI7L0eWUCCRGxfHeIEO-5">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="142.62" y="1270" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-67" value="define backend name" style="rounded=1;whiteSpace=wrap;html=1;arcSize=40;fontColor=#000000;fillColor=#ffffc0;strokeColor=#ff0000;align=center;verticalAlign=middle;fontFamily=Helvetica;fontSize=12;fontStyle=0;" vertex="1" parent="kiI7L0eWUCCRGxfHeIEO-1">
+          <mxGeometry x="82.69" y="980" width="120.62" height="40" as="geometry" />
+        </mxCell>
+        <mxCell id="kiI7L0eWUCCRGxfHeIEO-68" value="" style="edgeStyle=orthogonalEdgeStyle;html=1;verticalAlign=bottom;endArrow=open;endSize=8;strokeColor=#ff0000;rounded=0;fontFamily=Helvetica;fontSize=12;fontColor=default;fontStyle=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;" edge="1" parent="kiI7L0eWUCCRGxfHeIEO-1" source="kiI7L0eWUCCRGxfHeIEO-67" target="kiI7L0eWUCCRGxfHeIEO-60">
+          <mxGeometry relative="1" as="geometry">
+            <mxPoint x="223.13" y="1060" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+      </root>
+    </mxGraphModel>
+  </diagram>
+  <diagram id="gR3yDxqxX4bmJNmYeeSi" name="Page-4">
+    <mxGraphModel grid="1" page="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" pageScale="1" pageWidth="827" pageHeight="1169" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
       </root>
     </mxGraphModel>
   </diagram>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from pulser import Register as PasqalRegister
 from pulser.devices import Device
 
+from qiskit_pasqal_provider.providers.gate import InterpolatePoints
 from qiskit_pasqal_provider.providers.layouts import (
     SquareLayout,
 )
@@ -13,6 +14,36 @@ from qiskit_pasqal_provider.providers.target import (
     AVAILABLE_DEVICES,
     PasqalTarget,
 )
+
+
+@pytest.fixture
+def square_coords() -> list:
+    """simple square coordinates."""
+    return [(0, 0), (0, 1), (1, 0), (1, 1)]
+
+
+@pytest.fixture
+def null_interpolate_points() -> InterpolatePoints:
+    """constant null interpolate points instance."""
+    return InterpolatePoints(values=[0.0, 0.0, 0.0])
+
+
+@pytest.fixture
+def constant_interpolate_points() -> InterpolatePoints:
+    """constant 'normalized' interpolate points instance."""
+    return InterpolatePoints(values=[1.0, 1.0, 1.0, 1.0])
+
+
+@pytest.fixture
+def linear_interpolate_points() -> InterpolatePoints:
+    """linear interpolate points instance."""
+    return InterpolatePoints(values=[0.0, 1.0 / 3, 2.0 / 3, 1.0])
+
+
+@pytest.fixture
+def bump_interpolate_points() -> InterpolatePoints:
+    """bump interpolate points instance."""
+    return InterpolatePoints(values=[0.0, 1.0, 1.0, 0.0])
 
 
 @pytest.fixture

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1,0 +1,57 @@
+"""Testing `HamiltonianGate` and `InterpolatePoints` classes."""
+
+import pytest
+
+import numpy as np
+from qiskit.circuit import Parameter
+from qiskit.circuit.exceptions import CircuitError
+
+from qiskit_pasqal_provider.providers.pulse_utils import PasqalRegister
+from qiskit_pasqal_provider.providers.gate import HamiltonianGate, InterpolatePoints
+
+
+def test_interpolate_points() -> None:
+    """testing `InterpolatePoints` class correctness."""
+
+    p = Parameter("p")
+    t = Parameter("t")
+    values = [0, 1 / 3 * p, 2 / 3 * p, p]
+
+    wf = InterpolatePoints(values=values, duration=t)
+
+    assert all(
+        k == p == v
+        for k, p, v in zip(wf.values, np.array(values), values)  # type: ignore [arg-type]
+    )
+
+    with pytest.raises(AssertionError):
+        InterpolatePoints(values=values, duration="t")
+
+
+def test_analog_gate(
+    constant_interpolate_points: InterpolatePoints,
+    linear_interpolate_points: InterpolatePoints,
+    null_interpolate_points: InterpolatePoints,
+    square_coords: list,
+) -> None:
+    """testing `HamiltonianGate` class correctness"""
+
+    ampl = constant_interpolate_points
+    det = linear_interpolate_points
+    phase = null_interpolate_points
+
+    hg = HamiltonianGate(ampl, det, phase, coords=square_coords)
+
+    _analog_register = PasqalRegister.from_coordinates(square_coords, prefix="q")
+
+    assert np.all([hg.analog_register, _analog_register])  # type: ignore [arg-type]
+    assert np.all([hg.coords, _analog_register.qubits])  # type: ignore [arg-type]
+
+    with pytest.raises(AttributeError):
+        hg.control()
+
+    with pytest.raises(AttributeError):
+        hg.power(2.0)
+
+    with pytest.raises(CircuitError):
+        hg.to_matrix()


### PR DESCRIPTION
### Summary

Introducing the analog gate as discussed. It depends on defining amplitude (`Omega(t)`), detuning (`delta(t)`), phase (`phi(t)`) and qubit coordinates (an iterable with two iterables x and y). The time-dependent parameters should be defined through the `InterpolatePoints` class, which holds some relevant information regarding the points (`values`), duration, and interpolation technique.

### Tasks

- [x] add `HamiltonianGate`
- [x] add `InterpolatePoints` 
- [x] add tests

### Details and comments

Next steps:

- Strip off and refactor the `to_pulser` function and make the correct transformation from `qiskit` objects (especially `Paramater`) to `pulser` objects (in that case, `Variable` and related), at the backend level, where a `pulser.Sequence` would be defined and the parametrized values could be easily converted.
- Following the `qiskit` model to generate the backend and to use the sampler instance, make the code accordingly
