### PR TITLE
Add `times` argument for InterpolatePoints

### DIFF
--- a/qiskit_pasqal_provider/providers/gate.py
+++ b/qiskit_pasqal_provider/providers/gate.py
@@ -24,12 +24,19 @@ class InterpolatePoints:
     It should be used to generate the points for the `HamiltonianGate` instance.
     """
 
-    __slots__ = ("_values", "_duration", "_interpolator", "_interpolator_kwargs")
+    __slots__ = (
+        "_values",
+        "_duration",
+        "_times",
+        "_interpolator",
+        "_interpolator_kwargs",
+    )
 
     def __init__(
         self,
         values: ArrayLike,
         duration: int | float | ParameterExpression = 1000,  # think how to define it
+        times: ArrayLike | None = None,
         interpolator: str = "PchipInterpolator",
         **interpolator_kwargs: Any,
     ):
@@ -42,6 +49,7 @@ class InterpolatePoints:
             values: an array-like data representing the points to be interpolated.
                 It can be parametrized through `qiskit.circuit.Parameter`.
             duration: optional duration of the waveform (in ns). Defaults to 1000.
+            times: Fractions of the total duration (between 0 and 1). Optional.
             interpolator: The SciPy interpolation class to use. Supports
                 "PchipInterpolator" and "interp1d".
             **interpolator_kwargs: Extra parameters to give to the chosen
@@ -54,6 +62,7 @@ class InterpolatePoints:
         values = np.array(values)
         self._values = values
         self._duration = duration
+        self._times = times
         self._interpolator = interpolator
         self._interpolator_kwargs = interpolator_kwargs
 
@@ -66,6 +75,11 @@ class InterpolatePoints:
     def values(self) -> ArrayLike:
         """data points for interpolation"""
         return self._values
+
+    @property
+    def times(self) -> ArrayLike | None:
+        """normalized fraction of the total duration. Can be None"""
+        return self._times
 
     @property
     def interpolator(self) -> str:

--- a/qiskit_pasqal_provider/providers/pulse_utils.py
+++ b/qiskit_pasqal_provider/providers/pulse_utils.py
@@ -78,6 +78,9 @@ def _get_wf_values(
                 "Current Pasqal provider version does not support parametric expressions."
             )
 
+        case None:
+            return ()
+
         case _:
             raise NotImplementedError(f"values {type(values)} not supported.")
 
@@ -117,6 +120,7 @@ def gen_seq(
             amp_wf = InterpolatedWaveform(
                 duration=gate.amplitude.duration,
                 values=_get_wf_values(seq, gate.amplitude.values),
+                times=_get_wf_values(seq, gate.amplitude.times) or None,
                 interpolator=gate.amplitude.interpolator,
                 **gate.amplitude.interpolator_options,
             )
@@ -124,6 +128,7 @@ def gen_seq(
             det_wf = InterpolatedWaveform(
                 duration=gate.detuning.duration,
                 values=_get_wf_values(seq, gate.detuning.values),
+                times=_get_wf_values(seq, gate.detuning.times) or None,
                 interpolator=gate.detuning.interpolator,
                 **gate.detuning.interpolator_options,
             )

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -23,9 +23,15 @@ def test_interpolate_points() -> None:
         k == p == v
         for k, p, v in zip(wf.values, np.array(values), values)  # type: ignore [arg-type]
     )
+    assert wf.times is None
 
     with pytest.raises(AssertionError):
         InterpolatePoints(values=values, duration="t")
+
+    times = np.linspace(0, 1, num=len(values))
+    wf2 = InterpolatePoints(values=values, duration=t, times=times)
+
+    assert wf2.times is not None
 
 
 def test_analog_gate(


### PR DESCRIPTION
### Summary

Adding `times` argument to `InterpolatePoints` class, to reflect flexibility found in `pulser`'s [`InterpolateWaveform`](https://pulser.readthedocs.io/en/stable/tutorials/interpolated_wfs.html#Interpolated-Waveforms).


### Details and comments

Should work with or without specifying it explicitly, as found in `InterpolateWaveform` behavior.

