### PR TITLE
Quick fix: `StrEnum`

### DIFF
--- a/qiskit_pasqal_provider/providers/backend_base.py
+++ b/qiskit_pasqal_provider/providers/backend_base.py
@@ -20,7 +20,7 @@ from ..utils import PasqalEmulator
 if sys.version_info >= (3, 12):
     from enum import StrEnum
 else:
-    from qiskit_pasqal_provider.utils import StrEnum  # type: ignore [assignment]
+    from qiskit_pasqal_provider.utils import StrEnum
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Closes #16.

### Summary

Provides a working `StrEnum` class to check whether a `StrEnum` child class instance contains a given string.

### Details and comments

In Python 3.11 it is not possible to check whether a `StrEnum` child class instance contains a given string, e.g. `"a" in Alphabet`. It is valid from Python 3.12 onwards though. Hence, a custom `StrEnum` is used whenever the python version is less than 3.12.